### PR TITLE
Added Microsoft.Bcl.AsyncInterfaces package.

### DIFF
--- a/Rebus.AzureTables/Rebus.AzureTables.csproj
+++ b/Rebus.AzureTables/Rebus.AzureTables.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Data.Tables" Version="12.5.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="rebus" Version="6.6.4" />
   </ItemGroup>
 


### PR DESCRIPTION
Since we are working with IAsyncEnumerator and te target in .NET Standard 2.0, this package is needed

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
